### PR TITLE
Update frontend to connect to deployed backend

### DIFF
--- a/app/editor-v2/[roomid]/page.jsx
+++ b/app/editor-v2/[roomid]/page.jsx
@@ -32,7 +32,8 @@ export default function EditorPageV2() {
 
     console.log('🚀 V2: Initializing connection for room:', roomId);
 
-    const newSocket = io('http://localhost:3001', {
+    const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+    const newSocket = io(BACKEND_URL, {
       transports: ['websocket', 'polling'],
       timeout: 5000,
     });

--- a/app/editor/[roomid]/page.jsx
+++ b/app/editor/[roomid]/page.jsx
@@ -37,7 +37,8 @@ export default function EditorPage() {
 
     console.log('🚀 Initializing connection for room:', roomId);
 
-    const newSocket = io('http://localhost:3001', {
+    const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+    const newSocket = io(BACKEND_URL, {
       transports: ['websocket', 'polling'],
       timeout: 5000,
     });

--- a/app/editor/[roomid]/page_new.jsx
+++ b/app/editor/[roomid]/page_new.jsx
@@ -34,7 +34,8 @@ export default function EditorPage() {
 
     console.log('🚀 Initializing connection for room:', roomId);
 
-    const newSocket = io('http://localhost:3001', {
+    const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+    const newSocket = io(BACKEND_URL, {
       transports: ['websocket', 'polling'],
       timeout: 5000,
     });

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -5,16 +5,18 @@ const nextConfig = {
       allowedOrigins: ['localhost:3000']
     },
   },
-
-    reactStrictMode: false, // Temporarily disabled to prevent double useEffect execution
-    webpack(config, { isServer }) {
-      if (!isServer) {
-        // Disable Webpack caching for production build
-        config.cache = false;
-      }
-      return config;
-    },
-  };
+  env: {
+    NEXT_PUBLIC_BACKEND_URL: process.env.NEXT_PUBLIC_BACKEND_URL || 'https://cloudbasedcollborativecodeeditor-backend.onrender.com',
+  },
+  reactStrictMode: false, // Temporarily disabled to prevent double useEffect execution
+  webpack(config, { isServer }) {
+    if (!isServer) {
+      // Disable Webpack caching for production build
+      config.cache = false;
+    }
+    return config;
+  },
+};
   
   export default nextConfig;
   


### PR DESCRIPTION
- Add environment variable support for backend URL
- Configure next.config.mjs with NEXT_PUBLIC_BACKEND_URL
- Update socket connections in all editor pages to use deployed backend
- Set default backend URL to Render deployment: cloudbasedcollborativecodeeditor-backend.onrender.com
- Maintain localhost fallback for local development
- Add backend URL to .env.local for local development