### PR TITLE
Fix API calls to use deployed backend URL

### DIFF
--- a/app/create-project/page.jsx
+++ b/app/create-project/page.jsx
@@ -28,7 +28,8 @@ export default function CreateProjectPage() {
   useEffect(() => {
     const fetchTemplates = async () => {
       try {
-        const response = await fetch('http://localhost:3001/api/projects/templates');
+        const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+        const response = await fetch(`${BACKEND_URL}/api/projects/templates`);
         const data = await response.json();
         
         if (data.success) {
@@ -121,7 +122,8 @@ export default function CreateProjectPage() {
     console.log('🚀 Creating project with data:', formData);
 
     try {
-      const response = await fetch('http://localhost:3001/api/projects', {
+      const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+      const response = await fetch(`${BACKEND_URL}/api/projects`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/app/dashboard/page.jsx
+++ b/app/dashboard/page.jsx
@@ -21,7 +21,8 @@ export default function DashboardPage() {
 
   const fetchProjects = async () => {
     try {
-      const response = await fetch('http://localhost:3001/api/projects?userId=mock-user-id');
+      const BACKEND_URL = process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+      const response = await fetch(`${BACKEND_URL}/api/projects?userId=mock-user-id`);
       const data = await response.json();
       
       if (data.success) {

--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,35 @@
+// lib/api.js
+// Utility functions for API calls
+
+export const getBackendUrl = () => {
+  return process.env.NEXT_PUBLIC_BACKEND_URL || 'http://localhost:3001';
+};
+
+export const apiCall = async (endpoint, options = {}) => {
+  const baseUrl = getBackendUrl();
+  const url = `${baseUrl}${endpoint}`;
+  
+  const defaultOptions = {
+    headers: {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    },
+  };
+
+  const config = {
+    ...defaultOptions,
+    ...options,
+    headers: {
+      ...defaultOptions.headers,
+      ...options.headers,
+    },
+  };
+
+  try {
+    const response = await fetch(url, config);
+    return response;
+  } catch (error) {
+    console.error(`API call failed for ${endpoint}:`, error);
+    throw error;
+  }
+};


### PR DESCRIPTION
Critical fix for CORS issues:
- Update dashboard API call to use environment variable
- Update create-project API calls (templates and creation)
- Add lib/api.js utility for consistent backend URL handling
- Replace hardcoded localhost:3001 with dynamic backend URL
- Ensure all API calls work with deployed Render backend

This fixes the 'CORS request did not succeed' errors when fetching project templates and creating new projects.