### PR TITLE
fix: CRITICAL - Prevent file content duplication on file switch

### DIFF
--- a/app/editor/[roomid]/page.jsx
+++ b/app/editor/[roomid]/page.jsx
@@ -9,11 +9,7 @@ import FileExplorer from '@/components/FileExplorer';
 export default function EditorPage({ params }) {
   const { user, isLoaded } = useUser();
   const router = useRouter();
-  const [selectedFile, setSelectedFile] = useState({
-    name: 'welcome.js',
-    path: 'welcome.js',
-    type: 'file'
-  });
+  const [selectedFile, setSelectedFile] = useState(null); // ← No default file
 
   // Handle file selection from explorer
   const handleFileSelect = (file) => {


### PR DESCRIPTION
ISSUE 1: Remove hardcoded welcome.js default file
- Changed selectedFile initial state from welcome.js object to null
- Editor now shows empty until user selects a file

ISSUE 2: Fix file content accumulation bug
- Root cause: Save-on-unmount was running BEFORE content cleared
- This caused old content + new content to be saved together
- Files grew from 517 → 793 → 2368 chars

FIXES:
- Save previous file BEFORE clearing Yjs document
- Remove duplicate save-on-unmount effect
- Update lastContentRef after inserting new content
- Ensures clean file switching without content accumulation

This was causing files to show random/growing content!