### PR TITLE
fix: Auto-select main file on load and force S3 content on refresh

### DIFF
--- a/components/CollaborativeEditor.jsx
+++ b/components/CollaborativeEditor.jsx
@@ -118,24 +118,22 @@ const CollaborativeEditor = ({
         }
       }
       
-      // NOW clear and load new file
+      // NOW clear and load new file - ALWAYS update from S3 (source of truth)
       if (!initialContent) return;
       
-      const newContent = ytext.current.toString();
-      if (newContent !== initialContent) {
-        console.log(`🔄 Updating editor content for file: ${selectedFile?.name}`);
-        
-        // Clear existing content COMPLETELY
-        const currentLength = ytext.current.length;
-        if (currentLength > 0) {
-          ytext.current.delete(0, currentLength);
-        }
-        
-        // Insert new file content
-        if (initialContent) {
-          ytext.current.insert(0, initialContent);
-          lastContentRef.current = initialContent; // Update ref
-        }
+      console.log(`🔄 Loading fresh content for file: ${selectedFile?.name} (${initialContent.length} chars)`);
+      
+      // FORCE clear and reload - S3 is source of truth, not Yjs room
+      const currentLength = ytext.current.length;
+      if (currentLength > 0) {
+        ytext.current.delete(0, currentLength);
+      }
+      
+      // Insert fresh content from S3
+      if (initialContent) {
+        ytext.current.insert(0, initialContent);
+        lastContentRef.current = initialContent; // Update ref
+        console.log(`✅ Loaded fresh content from S3`);
       }
     };
     

--- a/components/FileExplorer.jsx
+++ b/components/FileExplorer.jsx
@@ -286,6 +286,23 @@ export default function FileExplorer({
       }
     });
 
+    // Auto-select main file on first load (index.js, main.js, app.js, or first .js file)
+    if (files.length > 0 && onSelect) {
+      const mainFile = files.find(f => 
+        f.name === 'index.js' || 
+        f.name === 'main.js' || 
+        f.name === 'app.js' ||
+        f.name === 'index.py' ||
+        f.name === 'main.py'
+      ) || files.find(f => f.name.endsWith('.js')) || files[0];
+      
+      if (mainFile) {
+        console.log(`🎯 Auto-selecting main file: ${mainFile.name}`);
+        // Delay to ensure parent component is ready
+        setTimeout(() => onSelect(mainFile), 100);
+      }
+    }
+
     // Sort items: folders first, then files, alphabetically
     const sortItems = (items) => {
       items.sort((a, b) => {

--- a/components/UnifiedMonacoEditor.jsx
+++ b/components/UnifiedMonacoEditor.jsx
@@ -43,7 +43,7 @@ const Editor = dynamic(() => import("@monaco-editor/react"), {
 });
 
 const UnifiedMonacoEditor = ({ selectedFile, roomid, projectFiles = [] }) => {
-  const [editorValue, setEditorValue] = useState("// Welcome to CodeDev Unified Collaborative Editor\n// ✨ All features integrated: IntelliSense, Real-time Collaboration, Code Analysis\n// 🚀 Start coding with enhanced productivity!\n\nconsole.log('Hello World!');\n\nfunction example() {\n  return 'Advanced Monaco Editor Ready!';\n}");
+  const [editorValue, setEditorValue] = useState(""); // Empty by default - will load from S3
   const [language, setLanguage] = useState("javascript");
   const [showAnalysisMode, setShowAnalysisMode] = useState(false);
   const [theme, setTheme] = useState('vs-dark');


### PR DESCRIPTION
- FileExplorer: Auto-select index.js/main.js/app.js on first load
- CollaborativeEditor: Always load fresh content from S3 (source of truth)
- UnifiedMonacoEditor: Remove hardcoded placeholder content
- Fixes issue #1: Default file selection
- Fixes issue #2: Content persistence after page refresh