### PR TITLE
fix: CRITICAL - Use file-specific Yjs rooms to prevent content mixing

### DIFF
--- a/components/UnifiedMonacoEditor.jsx
+++ b/components/UnifiedMonacoEditor.jsx
@@ -300,11 +300,14 @@ const UnifiedMonacoEditor = ({ selectedFile, roomid, projectFiles = [] }) => {
 
     if (isCollaborativeMode) {
       // Collaborative Mode - Full-featured editor with real-time collaboration
+      // Use file-specific room to prevent content mixing between files
+      const fileRoomId = selectedFile?.id ? `${roomid}-file-${selectedFile.id}` : roomid;
+      
       return (
-        <RoomProvider id={roomid} initialPresence={{ cursor: null, username: null, selection: null }}>
+        <RoomProvider id={fileRoomId} initialPresence={{ cursor: null, username: null, selection: null }}>
           <CollaborativeEditor
             selectedFile={selectedFile}
-            roomid={roomid}
+            roomid={fileRoomId}
             projectFiles={projectFiles}
             language={language}
             theme={theme}


### PR DESCRIPTION
Root cause analysis:
- All files shared same Yjs room (project room)
- Content from different files accumulated in same Yjs document
- Switching files caused content duplication/mixing

Solution:
- Each file now has own Yjs room: roomid-file-{fileId}
- Room change triggers Yjs reinitialization
- S3 content always loads fresh (source of truth)
- Removed save-before-switch (auto-save handles it)
- Simplified content loading logic

This should completely eliminate content duplication!